### PR TITLE
fix unused vars and disable restricted template rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,7 @@ module.exports = {
     },
   },
   rules: {
+    "@typescript-eslint/restrict-template-expressions": "off",
     "unicorn/prefer-node-remove": "off",
     "unicorn/prefer-spread": "off",
     "unicorn/filename-case": [

--- a/src/views/DatePickerGridView.ts
+++ b/src/views/DatePickerGridView.ts
@@ -15,6 +15,6 @@ export default class DatePickerGridView extends DatePickerBaseView
     model: DatePickerFactory,
     frameElement: HTMLElement
   ): void {
-    throw new Error('Override populateView');
+    throw new Error(`Override populateView in DatePickerGridView model:${model} frameElement:${frameElement}`);
   }
 }

--- a/src/views/DatePickerListView.ts
+++ b/src/views/DatePickerListView.ts
@@ -14,11 +14,10 @@ export default class DatePickerListView extends DatePickerBaseView
     this.frameElementClassName = 'date-picker-list';
   }
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  populateView(
+  protected populateView(
     model: DatePickerFactory,
     frameElement: HTMLElement
   ): void {
-    throw new Error('Override populateView');
+    throw new Error(`Override populateView in DatePickerListView model:${model} frameElement:${frameElement}`);
   }
 }


### PR DESCRIPTION
Used vars in the error message since abstract functions are only allowed in abstract classes