### PR TITLE
Feature/style current day on calendar

### DIFF
--- a/src/css/_calendar.css
+++ b/src/css/_calendar.css
@@ -15,3 +15,12 @@
   text-align: center;
   width: 14.2%;
 }
+
+.calendar .date-today {
+  border: solid pink 1px;
+}
+
+.calendar .ado-date-view {
+  height: 100%;
+  /* padding: unset; */
+}

--- a/src/css/_calendar.css
+++ b/src/css/_calendar.css
@@ -6,7 +6,7 @@
 .calendar > div {
   display: flex;
   flex-grow: 1;
-  height: 24px;
+  min-height: 24px;
   width: 100%;
 }
 
@@ -21,6 +21,8 @@
 }
 
 .calendar .ado-date-view {
+  display: flex;
+  flex-direction: column;
   height: 100%;
-  /* padding: unset; */
+  justify-content: center;
 }

--- a/src/css/_calendar.css
+++ b/src/css/_calendar.css
@@ -16,10 +16,6 @@
   width: 14.2%;
 }
 
-.calendar .date-today {
-  border: solid pink 1px;
-}
-
 .calendar .ado-date-view {
   display: flex;
   flex-direction: column;

--- a/src/css/_date.css
+++ b/src/css/_date.css
@@ -1,6 +1,6 @@
 .ado-date-view {
   background-color: bisque;
-  padding: 1em;
+  min-height: 30px;
 }
 
 .ado-date-view * {

--- a/src/css/_structure.css
+++ b/src/css/_structure.css
@@ -1,8 +1,11 @@
+.date-picker-view {
+  height: 100px;
+}
+
 .date-picker-view,
 .date-picker-grid,
 .date-picker-list {
   display: inline-block;
-  height: 100px;
   overflow: hidden;
   width: 200px;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,5 @@ const model = new DatePickerModel()
 const container = document.createElement('div')
 document.body.append(container)
 
-const datePickerControl = new DatePickerControl(model, container, [{ dateType: 7, viewType: 0, grouped: true, continuousScroll: false, looping: false, seedDate: new Date('December 17, 1995 03:24:00') }])
+const datePickerControl = new DatePickerControl(model, container, [{ dateType: 7, viewType: 0, grouped: true, continuousScroll: false, looping: false, seedDate: new Date() }])
 window.datePickerControl = datePickerControl;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,6 @@ declare global {
 
 const model = new DatePickerModel()
 const container = document.createElement('div')
-container.style.top = '100px';
 document.body.append(container)
 
 const datePickerControl = new DatePickerControl(model, container, [{ dateType: 7, viewType: 1, grouped: true, continuousScroll: true, looping: true, seedDate: new Date() }])

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,8 @@ declare global {
 
 const model = new DatePickerModel()
 const container = document.createElement('div')
+container.style.top = '100px';
 document.body.append(container)
 
-const datePickerControl = new DatePickerControl(model, container, [{ dateType: 7, viewType: 0, grouped: true, continuousScroll: false, looping: false, seedDate: new Date() }])
+const datePickerControl = new DatePickerControl(model, container, [{ dateType: 7, viewType: 1, grouped: true, continuousScroll: true, looping: true, seedDate: new Date() }])
 window.datePickerControl = datePickerControl;

--- a/src/models/WeekDateObject.ts
+++ b/src/models/WeekDateObject.ts
@@ -41,11 +41,10 @@ export default class WeekDateObject implements AtomicDateObject {
     // (splitWeek && month !== undefined)
 
     week.forEach((ado: AtomicDateObject, index: number) => {
-      const classList = ['weekday'];
+      const classList = ['weekday', 'ado-date-view'];
       let contentString = ado.viewString;
 
       if (!splitWeek || (month !== undefined && ado.date.getMonth() === month)) {
-        classList.push('ado-date-view')
         if (WeekDateObject.datesAreSameDay(ado.date, today)) {
           classList.push('date-today')
         }

--- a/src/models/datePickerFactory/DatePickerCreatorFuncs.ts
+++ b/src/models/datePickerFactory/DatePickerCreatorFuncs.ts
@@ -62,7 +62,6 @@ export const DatePickerCreatorFuncs = {
     // sets series to 0/sunday
     const dateTimeFormat = format;
     const seedDate = new Date(date.getTime());
-    console.log(`calendarHandlerCreator ${grouped}`)
 
     if (seedDate.getUTCDay() !== 0) {
       const delta = seedDate.getDate() - seedDate.getDay();

--- a/src/views/virtualDom/ContinuousScrollHandler.ts
+++ b/src/views/virtualDom/ContinuousScrollHandler.ts
@@ -66,7 +66,7 @@ export default class ContinuousScrollHandler {
     const { dataArray, dateElementHandlerFunction, frameElement, looping, model, targetHeight } = config;
 
     let index = 0;
-    while (frameElement.offsetHeight < targetHeight) {
+    while (frameElement.offsetHeight <= targetHeight) {
       if (index >= dataArray.length) {
         if (looping) {
           throw new Error("Looping view doesn't have enough dates");

--- a/src/views/virtualDom/VirtualDom.ts
+++ b/src/views/virtualDom/VirtualDom.ts
@@ -26,7 +26,7 @@ export default class VirtualDom {
     return array[array.length - 1];
   }
 
-  private buffer = 20;
+  private buffer = 10;
   private vdFrameElement: HTMLElement;
   private containerHeight: number;
 

--- a/src/views/virtualDom/VirtualDom.ts
+++ b/src/views/virtualDom/VirtualDom.ts
@@ -13,7 +13,7 @@ import AtomicDateObject from '../../models/AtomicDateObject';
 import BuildConfiguration from './BuildConfiguration';
 import ContinuousScrollHandler from './ContinuousScrollHandler';
 
-import { addElement } from './VirtualDomConst';
+import { addElement, OPEN_VIEW_HEIGHT } from './VirtualDomConst';
 import WeekDateObject from '../../models/WeekDateObject';
 
 // https://stackoverflow.com/questions/58036689/using-mutationobserver-to-detect-when-a-node-is-added-to-document
@@ -26,7 +26,7 @@ export default class VirtualDom {
     return array[array.length - 1];
   }
 
-  private buffer = 10;
+  private buffer = 20;
   private vdFrameElement: HTMLElement;
   private containerHeight: number;
 
@@ -45,9 +45,9 @@ export default class VirtualDom {
     deltaY = Math.min(Math.abs(deltaY), 3) * valence;
     let newTop = top + deltaY;
 
-    if (newTop > 0) {
+    if (newTop >= -(this.buffer * 0.5)) {
       newTop -= this.continuousScrollHandler.unshift();
-    } else if (newTop < -this.buffer) {
+    } else if (newTop < -(this.buffer * 2.1)) {
       newTop += this.continuousScrollHandler.push();
     }
 
@@ -132,7 +132,7 @@ export default class VirtualDom {
         'BuildView called without initialization. Initialize container element first.'
       );
     } else if (containerElement) {
-      this.containerHeight = containerElement.offsetHeight;
+      this.containerHeight = Math.max(containerElement.offsetHeight, OPEN_VIEW_HEIGHT)
     }
 
     if (className) {
@@ -145,7 +145,7 @@ export default class VirtualDom {
       dataArray: atomicDateObjectArray,
       continuousScroll: true,
       frameElement,
-      targetHeight: containerElement.offsetHeight + 2 * buffer,
+      targetHeight: this.containerHeight + (3 * buffer),
     };
 
     buildElementSetForVirtualDom(config);

--- a/src/views/virtualDom/VirtualDomConst.ts
+++ b/src/views/virtualDom/VirtualDomConst.ts
@@ -4,6 +4,7 @@ import WeekDateObject from '../../models/WeekDateObject';
 const NUM_ELEMENTS_LIMIT = 12;
 const DATA_TAG_STRING = 'data-element-index';
 const DATA_ADO_STRING = 'data-ado-index';
+const OPEN_VIEW_HEIGHT = 100;
 
 type DateElementHandlerFunction = (event: MouseEvent) => boolean;
 
@@ -35,5 +36,6 @@ export {
   DATA_ADO_STRING,
   DATA_TAG_STRING,
   DateElementHandlerFunction,
-  NUM_ELEMENTS_LIMIT
+  NUM_ELEMENTS_LIMIT,
+  OPEN_VIEW_HEIGHT
 }


### PR DESCRIPTION
Styling the current day turned out to be harder than I thought, and also surfaced a bug with the scrolling. Because the frame element had a fixed height, prepending elements actually prepended before/outside the dom element, and threw off the scrolling behavior, stacking all the elements in the prepend zone. This is now fixed.